### PR TITLE
Replace unmaintained tempdir by tempfile and memmap by mammap2.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ name = "seal"
 readme = "README.md"
 repository = "https://github.com/regexident/rust-seal"
 version = "0.1.1"
+edition = "2021"
 
 [dependencies]
 bitflags = "1.0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,6 @@ version = "0.1.1"
 
 [dependencies]
 bitflags = "1.0.4"
-memmap = "0.7.0"
-tempdir = "0.3.5"
+memmap2 = "0.5.0"
+tempfile = "3.2.0"
 uuid = { version = "0.8.2", features = ["v4"] }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,7 +1,5 @@
 // #![allow(dead_code, unused_variables, unused_imports)]
 
-extern crate seal;
-
 use std::fmt::Debug;
 
 use seal::pair::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,5 @@
 // pub mod basic_scoring;
 
-#[macro_use]
-extern crate bitflags;
-extern crate memmap2;
-extern crate tempfile;
-extern crate uuid;
-
 pub mod pair;
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,9 @@
 
 #[macro_use]
 extern crate bitflags;
-extern crate tempdir;
+extern crate memmap2;
+extern crate tempfile;
 extern crate uuid;
-extern crate memmap;
 
 pub mod pair;
 

--- a/src/pair/alignment.rs
+++ b/src/pair/alignment.rs
@@ -1,7 +1,7 @@
-use pair::cursor::Cursor;
-use pair::runs::Runs;
-use pair::step_mask::StepMask;
-use pair::steps::Steps;
+use crate::pair::cursor::Cursor;
+use crate::pair::runs::Runs;
+use crate::pair::step_mask::StepMask;
+use crate::pair::steps::Steps;
 
 #[derive(Debug)]
 pub struct Alignment {
@@ -47,8 +47,8 @@ impl Alignment {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pair::cursor::Cursor;
-    use pair::step_mask::StepMask;
+    use crate::pair::cursor::Cursor;
+    use crate::pair::step_mask::StepMask;
 
     fn origin() -> Cursor {
         Cursor { x: 3, y: 3 }

--- a/src/pair/alignment_matrix/in_memory.rs
+++ b/src/pair/alignment_matrix/in_memory.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
-use pair::cursor::Cursor;
-use pair::step_mask::StepMask;
+use crate::pair::cursor::Cursor;
+use crate::pair::step_mask::StepMask;
 
 use super::AlignmentMatrix as AlignmentMatrixTrait;
 

--- a/src/pair/alignment_matrix/memory_mapped.rs
+++ b/src/pair/alignment_matrix/memory_mapped.rs
@@ -1,7 +1,7 @@
 use std::{fmt, fs, io, mem};
 
-use memmap::MmapMut;
-use tempdir::TempDir;
+use memmap2::MmapMut;
+use tempfile::tempdir;
 use uuid::Uuid;
 
 use pair::cursor::Cursor;
@@ -25,10 +25,11 @@ impl AlignmentMatrixTrait for AlignmentMatrix {
     type Error = io::Error;
 
     fn new(width: usize, height: usize) -> Result<Self, Self::Error> {
-        let directory = TempDir::new("seal").unwrap();
+        let tempdir = tempdir()?;
+        let directory = tempdir.path().join("seal");
         let uuid = Uuid::new_v4();
         let filename = uuid.to_simple().to_string();
-        let path = directory.path().join(filename);
+        let path = directory.join(filename);
         let file = fs::OpenOptions::new()
             .read(true)
             .write(true)

--- a/src/pair/alignment_matrix/memory_mapped.rs
+++ b/src/pair/alignment_matrix/memory_mapped.rs
@@ -4,8 +4,8 @@ use memmap2::MmapMut;
 use tempfile::tempdir;
 use uuid::Uuid;
 
-use pair::cursor::Cursor;
-use pair::step_mask::StepMask;
+use crate::pair::cursor::Cursor;
+use crate::pair::step_mask::StepMask;
 
 use super::AlignmentMatrix as AlignmentMatrixTrait;
 

--- a/src/pair/alignment_matrix/mod.rs
+++ b/src/pair/alignment_matrix/mod.rs
@@ -1,4 +1,4 @@
-use pair::{cursor::Cursor, step_mask::StepMask};
+use crate::pair::{cursor::Cursor, step_mask::StepMask};
 
 pub mod in_memory;
 pub mod memory_mapped;

--- a/src/pair/alignment_set.rs
+++ b/src/pair/alignment_set.rs
@@ -1,11 +1,11 @@
 use std::cmp;
 
-use pair::alignment::Alignment;
-use pair::alignment_matrix::AlignmentMatrix;
-use pair::alignments::Alignments;
-use pair::cursor::Cursor;
-use pair::step_mask::StepMask;
-use pair::strategy::Strategy;
+use crate::pair::alignment::Alignment;
+use crate::pair::alignment_matrix::AlignmentMatrix;
+use crate::pair::alignments::Alignments;
+use crate::pair::cursor::Cursor;
+use crate::pair::step_mask::StepMask;
+use crate::pair::strategy::Strategy;
 
 #[derive(Copy, Clone)]
 struct Highscore {

--- a/src/pair/alignments.rs
+++ b/src/pair/alignments.rs
@@ -1,7 +1,7 @@
-use pair::alignment::Alignment;
-use pair::alignment_matrix::AlignmentMatrix;
-use pair::cursor::Cursor;
-use pair::step_mask::StepMask;
+use crate::pair::alignment::Alignment;
+use crate::pair::alignment_matrix::AlignmentMatrix;
+use crate::pair::cursor::Cursor;
+use crate::pair::step_mask::StepMask;
 
 pub struct Alignments<'a, T: 'a> {
     matrix: &'a T,

--- a/src/pair/cursor.rs
+++ b/src/pair/cursor.rs
@@ -1,4 +1,4 @@
-use pair::step_mask::StepMask;
+use crate::pair::step_mask::StepMask;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Cursor {

--- a/src/pair/needleman_wunsch.rs
+++ b/src/pair/needleman_wunsch.rs
@@ -1,5 +1,5 @@
-use pair::step_mask::StepMask;
-use pair::strategy::Strategy;
+use crate::pair::step_mask::StepMask;
+use crate::pair::strategy::Strategy;
 
 #[derive(Clone, Debug)]
 pub struct NeedlemanWunsch {

--- a/src/pair/run.rs
+++ b/src/pair/run.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use pair::step_mask::StepMask;
+use crate::pair::step_mask::StepMask;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Run {

--- a/src/pair/runs.rs
+++ b/src/pair/runs.rs
@@ -1,9 +1,8 @@
 use std::iter::Peekable;
 
-use pair::run::Run;
-use pair::step::Step;
-
-use pair::steps::Steps;
+use crate::pair::run::Run;
+use crate::pair::step::Step;
+use crate::pair::steps::Steps;
 
 pub struct Runs<'a> {
     inner: Peekable<Steps<'a>>,

--- a/src/pair/smith_waterman.rs
+++ b/src/pair/smith_waterman.rs
@@ -1,7 +1,7 @@
 use std::cmp;
 
-use pair::step_mask::StepMask;
-use pair::strategy::Strategy;
+use crate::pair::step_mask::StepMask;
+use crate::pair::strategy::Strategy;
 
 #[derive(Clone, Debug)]
 pub struct SmithWaterman {

--- a/src/pair/step.rs
+++ b/src/pair/step.rs
@@ -1,5 +1,5 @@
-use pair::run::Run;
-use pair::step_mask::StepMask;
+use crate::pair::run::Run;
+use crate::pair::step_mask::StepMask;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Step {

--- a/src/pair/step_mask.rs
+++ b/src/pair/step_mask.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)]
 use std::cmp;
 
+use bitflags::bitflags;
+
 bitflags! {
     pub struct StepMask: u8 {
         const STOP   = 0b00000000;

--- a/src/pair/steps.rs
+++ b/src/pair/steps.rs
@@ -1,8 +1,8 @@
 use std::slice::Iter;
 
-use pair::cursor::Cursor;
-use pair::step::Step;
-use pair::step_mask::StepMask;
+use crate::pair::cursor::Cursor;
+use crate::pair::step::Step;
+use crate::pair::step_mask::StepMask;
 
 pub struct Steps<'a> {
     pub inner: Iter<'a, StepMask>,

--- a/src/pair/strategy.rs
+++ b/src/pair/strategy.rs
@@ -1,4 +1,4 @@
-use pair::StepMask;
+use crate::pair::StepMask;
 
 pub trait Strategy: Clone {
     fn match_score(&self) -> isize;


### PR DESCRIPTION
This fixes the cargo audit warnings:

* https://rustsec.org/advisories/RUSTSEC-2018-0017
* https://rustsec.org/advisories/RUSTSEC-2020-0077

I also upgraded the crate to the Rust 2021 edition.