### PR TITLE
Remove unnecessary Clone requirement in Strategy

### DIFF
--- a/src/pair/strategy.rs
+++ b/src/pair/strategy.rs
@@ -1,6 +1,6 @@
 use crate::pair::StepMask;
 
-pub trait Strategy: Clone {
+pub trait Strategy {
     fn match_score(&self) -> isize;
     fn mismatch_score(&self) -> isize;
     fn insert_score(&self) -> isize;


### PR DESCRIPTION
Having `Clone` be required makes `Strategy` not dyn safe unnecessarily